### PR TITLE
Convert any given canvas_id to a jQuery element

### DIFF
--- a/scripts/vispy.js
+++ b/scripts/vispy.js
@@ -19,12 +19,7 @@ var Vispy = function() {
 
 Vispy.prototype.init = function(canvas_id) {
     var canvas_el;
-    if (typeof canvas_id === 'string') {
-        canvas_el = $(canvas_id);
-    }
-    else {
-        canvas_el = canvas_id;
-    }
+    canvas_el = $(canvas_id);
     // Initialize the canvas.
     var canvas = new VispyCanvas(canvas_el);
 


### PR DESCRIPTION
I had the problem that I gave `vispy.init()` the canvas DOM element, which is not a string, which is why it did not get "jQuery-fied". I tested that this even works if you pass a jQuery object.
