### PR TITLE
Add ability to do subimage and float texture stores

### DIFF
--- a/scripts/gloo.js
+++ b/scripts/gloo.js
@@ -15,6 +15,19 @@ function init_webgl(c) {
     if (ext === null) {
         console.warn('Extension \'OES_element_index_uint\' is not supported in this browser. Some features may not work as expected');
     }
+    var ext = c.gl.getExtension('OES_texture_float');
+    // ||
+    //     c.gl.getExtension('MOZ_OES_element_index_uint') ||
+    //     c.gl.getExtension('WEBKIT_OES_element_index_uint');
+    if (ext === null) {
+        console.warn('Extension \'OES_texture_float\' is not supported in this browser. Some features may not work as expected');
+    }
+
+    var ext = c.gl.getExtension('OES_texture_float_linear');
+    if (ext === null) {
+        console.warn('Extension \'OES_texture_float_linear\' is not supported in this browser. Some features may not work as expected');
+    }
+
     // c.gl.getExtension('EXT_shader_texture_lod');
 }
 


### PR DESCRIPTION
@larsoner updated vispy python to give the option of `cpu` or `gpu` text rendering. The default way that the `cpu` method was using required 32-bit float data textures and used subimage texture writing. This PR adds both of those things even though we ended up not using the 32-bit float stuff. This shouldn't affect anyone using a browser that doesn't support these attachments.

See vispy PR here: https://github.com/larsoner/vispy/pull/6
And @larsoner's original PR: https://github.com/vispy/vispy/pull/1409