### PR TITLE
Fix uniform cache not being reset after program linking

### DIFF
--- a/lib/gloo.glir.js
+++ b/lib/gloo.glir.js
@@ -478,7 +478,9 @@ glir.prototype.create = function(c, args) {
             object_type: cls,
             handle: c.gl.createProgram(),
             attributes: {},
-            uniforms: {},
+            _handles_cache: {}, // uniform and attributes handle cache
+            // _unset_variables: new Set([]),
+            // _known_invalid: new Set([]),
             textures: {}, // map texture_id -> sampler_name, sampler_handle, number, handle
             texture_uniforms: {}, // map sampler_name -> texture_id
             shaders: {}
@@ -627,7 +629,8 @@ glir.prototype.attribute = function(c, args) {
     var stride = args[3][1];
     var offset = args[3][2];
 
-    var program_handle = c._ns[program_id].handle;
+    var program_obj = c._ns[program_id];
+    var program_handle = program_obj.handle;
 
     debug("Creating attribute '{0}' for program '{1}'.".format(
             name, program_id
@@ -635,7 +638,7 @@ glir.prototype.attribute = function(c, args) {
     var attribute_handle = create_attribute(c, program_handle, name);
 
     // Store the attribute handle in the attributes array of the program.
-    c._ns[program_id].attributes[name] = {
+    program_obj.attributes[name] = {
         handle: attribute_handle,
         type: type,
         vbo_id: vbo_id,
@@ -650,30 +653,39 @@ glir.prototype.uniform = function(c, args) {
     var type = args[2];
     var value = args[3];
 
-    var program_handle = c._ns[program_id].handle;
+    var program_obj = c._ns[program_id];
+    var program_handle = program_obj.handle;
     var uniform_handle;
     var uniform_function;
     var uniform_info;
 
-    c.gl.useProgram(program_handle);
-
     // Check the cache.
-    if (c._ns[program_id].uniforms[name] == undefined) {
+    if (program_obj._handles_cache[name] === undefined) {
+        // if (program_obj._known_invalid.has(name)) {
+        //     return;
+        // }
         // If necessary, we create the uniform and cache both its handle and
         // GL function.
         debug("Creating uniform '{0}' for program '{1}'.".format(
                 name, program_id
             ));
         uniform_handle = c.gl.getUniformLocation(program_handle, name);
+        // program_obj._unset_variables.delete(name);
         uniform_function = get_uniform_function(type);
         // We cache the uniform handle and the uniform function name as well.
-        c._ns[program_id].uniforms[name] = [uniform_handle, uniform_function];
+        program_obj._handles_cache[name] = [uniform_handle, uniform_function];
+        // if (uniform_handle === null) {
+        //     program_obj._known_invalid.add(name);
+        //     return;
+        // }
     }
+
+    c.gl.useProgram(program_handle);
 
     debug("Setting uniform '{0}' to '{1}' with {2} elements.".format(
             name, value, value.length
         ));
-    uniform_info = c._ns[program_id].uniforms[name];
+    uniform_info = c._ns[program_id]._handles_cache[name];
     uniform_handle = uniform_info[0];
     uniform_function = uniform_info[1];
     set_uniform(c, uniform_handle, uniform_function, value);
@@ -905,6 +917,7 @@ glir.prototype.link = function(c, args) {
     }
     // reset link to all shaders
     program_obj.shaders = {};
+    program_obj._handles_cache = {};
 
 };
 


### PR DESCRIPTION
For anyone reading this thinking "how does Dave debug/find this stuff", the answer is: compare the python code to the javascript code. When you find something that python is doing that the javascript is not, then ask yourself "is the python code doing something that is 'extra' or something that is necessary"? If the answer is "extra" then it may be best to not implement it in vispy.js because of the extra performance. If it is necessary then figure out how to implement it in javascript.

This PR is a little bit of both. The unnecessary part is that the python code does a lot of checks to see if uniforms are declared in the shader code but not set, or if there are variables that are created in the shader but not used. These checks are complex to implement when it comes to matrix uniforms and so I consider it not worth it when vispy.js is already slow. I didn't realize this was technically unnecessary until after I had started working on it. There are some comments left in to finish this implementation in the future if needed.

The necessary part of this PR is that we clear the cache of uniform handles after the program is linked. This cache is meant to connect a uniform's name to its "location" in the GPU. Once the program is linked, this information is no longer valid and was causing issues when it was reused.