### PR TITLE
Fix sign of mouse scroll events

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -456,10 +456,8 @@ function init_app(c) {
     // This requires the mouse wheel jquery plugin.
     c.$el.on("wheel", function(e) {
         var event = gen_mouse_event(c, e, 'mouse_wheel');
-        // event.delta = [e.originalEvent.deltaX * e.deltaFactor * 0.01,
-        //                e.originalEvent.deltaY * e.deltaFactor * 0.01];
         event.delta = [e.originalEvent.deltaX * 0.01,
-            e.originalEvent.deltaY * 0.01];
+                       -e.originalEvent.deltaY * 0.01];
 
         // Vispy callbacks.
         c._mouse_wheel(event);


### PR DESCRIPTION
The sign of the mouse wheel event delta was changed in commit
855febc. This makes the sign once more consistent with other vispy
backends.