### PR TITLE
Add ability to pass webGL context arguments for canvas initialization

### DIFF
--- a/lib/gloo.js
+++ b/lib/gloo.js
@@ -1,10 +1,10 @@
 var glir = require('./gloo.glir.js');
 
-function init_webgl(c) {
+function init_webgl(c, canvas_args) {
     // Get the DOM object, not the jQuery one.
     var canvas = c.$el.get(0);
-    c.gl = canvas.getContext("webgl") ||
-           canvas.getContext("experimental-webgl");
+    c.gl = canvas.getContext("webgl", canvas_args) ||
+           canvas.getContext("experimental-webgl", canvas_args);
     var ext = c.gl.getExtension('OES_standard_derivatives') || c.gl.getExtension('MOZ_OES_standard_derivatives') || c.gl.getExtension('WEBKIT_OES_standard_derivatives');
     if (ext === null) {
         console.warn('Extension \'OES_standard_derivatives\' is not supported in this browser. Some features may not work as expected');
@@ -39,8 +39,8 @@ var gloo = function() {
 
 };
 
-gloo.prototype.init = function(c) {
-    init_webgl(c);
+gloo.prototype.init = function(c, canvas_args) {
+    init_webgl(c, canvas_args);
     this.glir.init(c);
 };
 

--- a/lib/vispy.js
+++ b/lib/vispy.js
@@ -12,7 +12,7 @@ var Vispy = function() {
     this._canvases = [];
 };
 
-Vispy.prototype.init = function(canvas_id) {
+Vispy.prototype.init = function(canvas_id, canvas_options) {
     var canvas_el;
     canvas_el = $(canvas_id);
     // Initialize the canvas.
@@ -24,7 +24,7 @@ Vispy.prototype.init = function(canvas_id) {
     this.events.init(canvas);
 
     // Initialize WebGL.
-    this.gloo.init(canvas);
+    this.gloo.init(canvas, canvas_options);
 
     // Register the canvas.
     this.register(canvas);

--- a/lib/webgl-backend.js
+++ b/lib/webgl-backend.js
@@ -55,7 +55,7 @@ var VispyView = widgets.DOMWidgetView.extend({
             this.$canvas = canvas;
 
             // Initialize the VispyCanvas.
-            this.c = vispy.init(canvas);
+            this.c = vispy.init(canvas, this.model.get('webgl_config'));
 
             this.c.on_resize(function (e) {
                 that.model.set('width', e.size[0]);


### PR DESCRIPTION
This change is a prerequisite for vispy/vispy#1693. This infrastructure allows for other options to be passed to the webGL canvas initialization.